### PR TITLE
Refresh README after OSS foundation epic completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,29 @@
 # redteaming-ai
 
-`redteaming-ai` is an interactive demo project for exploring common security failure modes in LLM-integrated applications.
+`redteaming-ai` is an alpha open-source red-teaming project for exploring common security failure modes in LLM-integrated applications.
 
-Today, this repo is best understood as an educational demo, not a full red-teaming platform. It is useful for experimenting with prompt injection, data exfiltration, jailbreak-style prompts, and unsafe tool exposure in a controlled local environment. The long-term goal is to evolve it into a more credible open-source red-teaming system with reproducible runs, stronger evaluation, and real target integrations.
+Today, this repo is best understood as a credible OSS foundation with demo-friendly entrypoints, not a finished platform. It is useful for experimenting with prompt injection, data exfiltration, jailbreak-style prompts, unsafe tool exposure, persisted assessments, and evaluator-backed reporting in a controlled local environment. It is still intentionally small in scope and not yet a high-confidence assessment system for real production applications.
 
 ## Current Status
 
-- Working demo: yes
-- Production-ready platform: no
+- Packaged CLI and API: yes
+- Reproducible local workflow and CI: yes
 - Good for presentations, local experimentation, and teaching: yes
+- Production-ready platform: no
 - Good for assessing real systems with high confidence: not yet
 
 The codebase currently centers on:
 
 - a deliberately vulnerable sample app
 - a managed attack corpus with seeded generation strategies
-- a CLI demo flow
-- a Streamlit demo UI
+- packaged CLI and API assessment flows
+- a CLI demo flow and Streamlit demo UI
 
 ## What This Repo Is
 
 - A compact sandbox for demonstrating common LLM security problems
-- A starting point for an OSS red-teaming project
-- A place to experiment locally before the platform architecture is built out
+- A small but structured OSS red-teaming foundation
+- A place to experiment locally with reproducible runs, persisted reports, and evaluator-backed findings
 
 ## What This Repo Is Not Yet
 
@@ -176,19 +177,14 @@ These are current limitations, not hidden gotchas:
 
 If you are evaluating whether this repo is ready to assess a real application, the honest answer is no. If you want a demo you can run locally, modify, and learn from, the answer is yes.
 
-## Roadmap
+## Project Status
 
-The public roadmap is tracked in GitHub:
+The OSS foundation epic is complete:
 
 - Epic: [#14](https://github.com/nnennandukwe/redteaming-ai/issues/14)
-- Correctness and trust fixes: [#9](https://github.com/nnennandukwe/redteaming-ai/issues/9)
-- Test and CI foundation: [#8](https://github.com/nnennandukwe/redteaming-ai/issues/8)
-- OSS readiness: [#11](https://github.com/nnennandukwe/redteaming-ai/issues/11)
-- README and messaging cleanup: [#13](https://github.com/nnennandukwe/redteaming-ai/issues/13)
-- Package structure and architecture: [#1](https://github.com/nnennandukwe/redteaming-ai/issues/1)
-- Config, storage, API, adapters, evaluation, fuzzing, and reporting: [#2](https://github.com/nnennandukwe/redteaming-ai/issues/2), [#3](https://github.com/nnennandukwe/redteaming-ai/issues/3), [#4](https://github.com/nnennandukwe/redteaming-ai/issues/4), [#5](https://github.com/nnennandukwe/redteaming-ai/issues/5), [#6](https://github.com/nnennandukwe/redteaming-ai/issues/6), [#7](https://github.com/nnennandukwe/redteaming-ai/issues/7), [#10](https://github.com/nnennandukwe/redteaming-ai/issues/10), [#12](https://github.com/nnennandukwe/redteaming-ai/issues/12)
+- Core outcomes: packaged CLI and API flows, persistent storage, adapter boundaries, evaluator-backed grading, structured reporting, seeded corpus workflows, automated tests, and a cross-platform `uv`-based developer workflow
 
-The current implementation work is focused on making the public repo accurate first, then building the platform foundations behind it.
+From here, the project can deepen target integrations, evaluation quality, and user experience without needing another repository-setup pass first.
 
 ## Safety Note
 


### PR DESCRIPTION
## Summary
- update the top-level README positioning to reflect the current alpha OSS foundation state
- replace the stale roadmap section with a completed project-status summary
- keep the messaging honest about what is implemented now versus what is still not production-ready

## Verification
- `git diff --check`
- manual README review against merged epic and repo state
