### PR TITLE
feat: add request ID middleware and safe logging

### DIFF
--- a/src/redteaming_ai/api.py
+++ b/src/redteaming_ai/api.py
@@ -21,6 +21,7 @@ from redteaming_ai.api_models import (
 from redteaming_ai.assessment_service import AssessmentRunner, AssessmentService
 from redteaming_ai.observability import (
     REQUEST_ID_HEADER,
+    log_error,
     log_info,
     log_warning,
     request_id_context,
@@ -69,7 +70,22 @@ def create_app(
         request_id = resolve_request_id(request.headers.get(REQUEST_ID_HEADER))
         request.state.request_id = request_id
         with request_id_context(request_id):
-            response = await call_next(request)
+            try:
+                response = await call_next(request)
+            except Exception as exc:
+                log_error(
+                    logger,
+                    "request_processing",
+                    "failed",
+                    method=request.method,
+                    path=request.url.path,
+                    error_type=type(exc).__name__,
+                    hint="Inspect application logs for the server-side failure.",
+                )
+                response = JSONResponse(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    content={"detail": "Internal Server Error"},
+                )
         response.headers[REQUEST_ID_HEADER] = request_id
         return response
 

--- a/src/redteaming_ai/api.py
+++ b/src/redteaming_ai/api.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from concurrent.futures import Executor
 from contextlib import asynccontextmanager
 from pathlib import Path
@@ -7,6 +8,8 @@ from typing import Optional
 
 import uvicorn
 from fastapi import Depends, FastAPI, HTTPException, Query, Request, status
+from fastapi.exception_handlers import request_validation_exception_handler
+from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, PlainTextResponse
 
 from redteaming_ai.api_models import (
@@ -16,7 +19,18 @@ from redteaming_ai.api_models import (
     ReportResponse,
 )
 from redteaming_ai.assessment_service import AssessmentRunner, AssessmentService
+from redteaming_ai.observability import (
+    REQUEST_ID_HEADER,
+    log_info,
+    log_warning,
+    request_id_context,
+    resolve_request_id,
+    safe_validation_errors,
+    sanitize_text,
+)
 from redteaming_ai.storage import RunStorage
+
+logger = logging.getLogger("redteaming_ai.api")
 
 
 def get_assessment_service(request: Request) -> AssessmentService:
@@ -50,6 +64,28 @@ def create_app(
         lifespan=lifespan,
     )
 
+    @app.middleware("http")
+    async def request_id_middleware(request: Request, call_next):
+        request_id = resolve_request_id(request.headers.get(REQUEST_ID_HEADER))
+        request.state.request_id = request_id
+        with request_id_context(request_id):
+            response = await call_next(request)
+        response.headers[REQUEST_ID_HEADER] = request_id
+        return response
+
+    @app.exception_handler(RequestValidationError)
+    async def handle_validation_error(request: Request, exc: RequestValidationError):
+        log_warning(
+            logger,
+            "request_validation",
+            "invalid",
+            method=request.method,
+            path=request.url.path,
+            validation_errors=safe_validation_errors(exc.errors()),
+            hint="Fix the request payload so it matches the API schema.",
+        )
+        return await request_validation_exception_handler(request, exc)
+
     @app.post(
         "/assessments",
         response_model=AssessmentResponse,
@@ -74,7 +110,23 @@ def create_app(
                 campaign_config=campaign_config,
             )
         except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc)) from exc
+            log_warning(
+                logger,
+                "assessment_create",
+                "rejected",
+                error_type=type(exc).__name__,
+                target_type=payload.target_type,
+                hint="Check target configuration and required fields.",
+            )
+            raise HTTPException(status_code=400, detail=sanitize_text(str(exc))) from exc
+        log_info(
+            logger,
+            "assessment_create",
+            "accepted",
+            run_id=run["id"],
+            target_type=payload.target_type,
+            status=run["status"],
+        )
         return AssessmentResponse(**run)
 
     @app.get("/assessments/{run_id}", response_model=AssessmentResponse)

--- a/src/redteaming_ai/assessment_service.py
+++ b/src/redteaming_ai/assessment_service.py
@@ -1,14 +1,23 @@
 from __future__ import annotations
 
+import logging
 from concurrent.futures import Executor, ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional, Type
 
 from redteaming_ai.adapters import normalize_target_spec, resolve_target_spec
 from redteaming_ai.agents import RedTeamOrchestrator
+from redteaming_ai.observability import (
+    get_request_id,
+    log_error,
+    log_info,
+    request_id_context,
+    sanitize_text,
+)
 from redteaming_ai.storage import RunStorage
 
 AssessmentRunner = Callable[[RunStorage, str, Dict[str, Any]], None]
+logger = logging.getLogger("redteaming_ai.assessment_service")
 
 
 def default_assessment_runner(
@@ -85,7 +94,12 @@ class AssessmentService:
 
         runner_target = spec.to_dict()
         runner_target["campaign_config"] = campaign_config
-        self.executor.submit(self._execute_assessment, run_id, runner_target)
+        self.executor.submit(
+            self._execute_assessment,
+            run_id,
+            runner_target,
+            get_request_id(),
+        )
         run = self.get_assessment(run_id)
         if not run:
             raise ValueError(f"Run {run_id} was not created")
@@ -144,14 +158,43 @@ class AssessmentService:
         finally:
             storage.close()
 
-    def _execute_assessment(self, run_id: str, target: Dict[str, Any]) -> None:
-        storage = self._open_storage()
-        try:
-            self.assessment_runner(storage, run_id, target)
-        except Exception as exc:
-            storage.mark_run_failed(run_id, str(exc))
-        finally:
-            storage.close()
+    def _execute_assessment(
+        self, run_id: str, target: Dict[str, Any], request_id: Optional[str] = None
+    ) -> None:
+        with request_id_context(request_id):
+            storage = self._open_storage()
+            log_info(
+                logger,
+                "assessment_execution",
+                "started",
+                run_id=run_id,
+                target_type=target.get("target_type"),
+            )
+            try:
+                self.assessment_runner(storage, run_id, target)
+            except Exception as exc:
+                safe_error_message = sanitize_text(str(exc))
+                storage.mark_run_failed(run_id, safe_error_message)
+                log_error(
+                    logger,
+                    "assessment_execution",
+                    "failed",
+                    run_id=run_id,
+                    target_type=target.get("target_type"),
+                    error_type=type(exc).__name__,
+                    error_message=safe_error_message,
+                    hint="Inspect the stored run error_message for sanitized failure details.",
+                )
+            else:
+                log_info(
+                    logger,
+                    "assessment_execution",
+                    "completed",
+                    run_id=run_id,
+                    target_type=target.get("target_type"),
+                )
+            finally:
+                storage.close()
 
     def _build_assessment_response(self, run: Dict[str, Any]) -> Dict[str, Any]:
         summary = None

--- a/src/redteaming_ai/observability.py
+++ b/src/redteaming_ai/observability.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import re
+import uuid
+from contextlib import contextmanager
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional
+
+REQUEST_ID_HEADER = "X-Request-ID"
+SERVICE_NAME = "redteaming-ai-api"
+
+_REQUEST_ID = contextvars.ContextVar("redteaming_ai_request_id", default=None)
+_REQUEST_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_EMAIL_PATTERN = re.compile(r"\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b", re.IGNORECASE)
+_PHONE_PATTERN = re.compile(r"(?<!\w)(?:\+?\d[\d(). -]{7,}\d)")
+_BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[A-Z0-9._~+/-]+=*")
+_HEADER_SECRET_PATTERN = re.compile(
+    r"(?i)\b(authorization|cookie)\s*:\s*([^\s,;]+(?:\s+[^\s,;]+)*)"
+)
+_ASSIGNMENT_SECRET_PATTERN = re.compile(
+    r"(?i)\b(token|secret|password|api[_-]?key)\b\s*[:=]\s*([^\s,;]+)"
+)
+
+_SENSITIVE_KEY_PARTS = (
+    "authorization",
+    "cookie",
+    "token",
+    "secret",
+    "password",
+    "api_key",
+    "apikey",
+    "email",
+    "phone",
+    "payload",
+    "response",
+    "prompt",
+    "body",
+    "text",
+)
+_SAFE_KEYS = {
+    "error_message",
+    "error_type",
+    "hint",
+    "method",
+    "path",
+    "request_id",
+    "run_id",
+    "status",
+    "status_code",
+    "target_type",
+    "validation_errors",
+}
+
+
+def normalize_request_id(value: Optional[str]) -> Optional[str]:
+    if value is None:
+        return None
+    request_id = value.strip()
+    if not request_id or len(request_id) > 128:
+        return None
+    if _REQUEST_ID_PATTERN.fullmatch(request_id) is None:
+        return None
+    return request_id
+
+
+def resolve_request_id(value: Optional[str]) -> str:
+    return normalize_request_id(value) or str(uuid.uuid4())
+
+
+def get_request_id() -> Optional[str]:
+    return _REQUEST_ID.get()
+
+
+@contextmanager
+def request_id_context(request_id: Optional[str]) -> Iterator[Optional[str]]:
+    token = _REQUEST_ID.set(request_id)
+    try:
+        yield request_id
+    finally:
+        _REQUEST_ID.reset(token)
+
+
+def sanitize_text(value: Any) -> str:
+    text = str(value)
+    text = _HEADER_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}: [redacted]", text)
+    text = _ASSIGNMENT_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
+    text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
+    text = _EMAIL_PATTERN.sub("[redacted-email]", text)
+    text = _PHONE_PATTERN.sub("[redacted-phone]", text)
+    return text
+
+
+def safe_validation_errors(errors: Iterable[Mapping[str, Any]]) -> list[Dict[str, Any]]:
+    sanitized = []
+    for error in errors:
+        sanitized.append(
+            {
+                "loc": [str(part) for part in error.get("loc", ())],
+                "type": sanitize_text(error.get("type", "validation_error")),
+            }
+        )
+    return sanitized
+
+
+def log_event(
+    logger: logging.Logger,
+    level: int,
+    operation: str,
+    outcome: str,
+    **fields: Any,
+) -> Dict[str, Any]:
+    event: Dict[str, Any] = {
+        "service": SERVICE_NAME,
+        "operation": operation,
+        "outcome": outcome,
+    }
+    request_id = fields.pop("request_id", None) or get_request_id()
+    if request_id:
+        event["request_id"] = request_id
+
+    for key, value in fields.items():
+        if value is None:
+            continue
+        event[key] = _sanitize_field(key, value)
+
+    logger.log(level, json.dumps(event, sort_keys=True))
+    return event
+
+
+def log_info(logger: logging.Logger, operation: str, outcome: str, **fields: Any) -> Dict[str, Any]:
+    return log_event(logger, logging.INFO, operation, outcome, **fields)
+
+
+def log_warning(
+    logger: logging.Logger, operation: str, outcome: str, **fields: Any
+) -> Dict[str, Any]:
+    return log_event(logger, logging.WARNING, operation, outcome, **fields)
+
+
+def log_error(logger: logging.Logger, operation: str, outcome: str, **fields: Any) -> Dict[str, Any]:
+    return log_event(logger, logging.ERROR, operation, outcome, **fields)
+
+
+def _sanitize_field(key: str, value: Any) -> Any:
+    if key == "validation_errors":
+        return safe_validation_errors(value)
+    if _is_sensitive_key(key) or key not in _SAFE_KEYS:
+        return "[redacted]"
+    if isinstance(value, (bool, int, float)):
+        return value
+    if isinstance(value, Mapping):
+        return "[redacted]"
+    if isinstance(value, (list, tuple, set)):
+        return [sanitize_text(item) for item in value]
+    return sanitize_text(value)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(part in normalized for part in _SENSITIVE_KEY_PARTS)

--- a/src/redteaming_ai/observability.py
+++ b/src/redteaming_ai/observability.py
@@ -19,9 +19,19 @@ _BEARER_PATTERN = re.compile(r"(?i)\bbearer\s+[A-Z0-9._~+/-]+=*")
 _HEADER_SECRET_PATTERN = re.compile(
     r"(?i)\b(authorization|cookie)\s*:\s*([^\s,;]+(?:\s+[^\s,;]+)*)"
 )
+_QUOTED_SECRET_PATTERN = re.compile(
+    r"""(?ix)
+    (["']?(?:authorization|cookie|token|secret|password|api[_-]?key)["']?\s*[:=]\s*)
+    (["'])
+    (?:\\.|(?!\2).)*
+    \2
+    """
+)
 _ASSIGNMENT_SECRET_PATTERN = re.compile(
     r"(?i)\b(token|secret|password|api[_-]?key)\b\s*[:=]\s*([^\s,;]+)"
 )
+_SAFE_LOC_PARTS = {"body", "query", "path", "header", "cookie"}
+_SAFE_LOC_IDENTIFIER_PATTERN = re.compile(r"^[A-Za-z_][A-Za-z0-9_]{0,63}$")
 
 _SENSITIVE_KEY_PARTS = (
     "authorization",
@@ -52,6 +62,7 @@ _SAFE_KEYS = {
     "target_type",
     "validation_errors",
 }
+_RAW_STRING_SAFE_KEYS = {"request_id", "run_id"}
 
 
 def normalize_request_id(value: Optional[str]) -> Optional[str]:
@@ -85,6 +96,10 @@ def request_id_context(request_id: Optional[str]) -> Iterator[Optional[str]]:
 def sanitize_text(value: Any) -> str:
     text = str(value)
     text = _HEADER_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}: [redacted]", text)
+    text = _QUOTED_SECRET_PATTERN.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}[redacted]{match.group(2)}",
+        text,
+    )
     text = _ASSIGNMENT_SECRET_PATTERN.sub(lambda match: f"{match.group(1)}=[redacted]", text)
     text = _BEARER_PATTERN.sub("Bearer [redacted]", text)
     text = _EMAIL_PATTERN.sub("[redacted-email]", text)
@@ -97,7 +112,7 @@ def safe_validation_errors(errors: Iterable[Mapping[str, Any]]) -> list[Dict[str
     for error in errors:
         sanitized.append(
             {
-                "loc": [str(part) for part in error.get("loc", ())],
+                "loc": [_sanitize_loc_part(part) for part in error.get("loc", ())],
                 "type": sanitize_text(error.get("type", "validation_error")),
             }
         )
@@ -148,6 +163,8 @@ def _sanitize_field(key: str, value: Any) -> Any:
         return safe_validation_errors(value)
     if _is_sensitive_key(key) or key not in _SAFE_KEYS:
         return "[redacted]"
+    if key in _RAW_STRING_SAFE_KEYS:
+        return str(value)
     if isinstance(value, (bool, int, float)):
         return value
     if isinstance(value, Mapping):
@@ -160,3 +177,17 @@ def _sanitize_field(key: str, value: Any) -> Any:
 def _is_sensitive_key(key: str) -> bool:
     normalized = key.lower()
     return any(part in normalized for part in _SENSITIVE_KEY_PARTS)
+
+
+def _sanitize_loc_part(part: Any) -> Any:
+    if isinstance(part, int):
+        return part
+
+    text = sanitize_text(part)
+    if text in _SAFE_LOC_PARTS:
+        return text
+    if _is_sensitive_key(text):
+        return "[redacted]"
+    if _SAFE_LOC_IDENTIFIER_PATTERN.fullmatch(text):
+        return text
+    return "[redacted]"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -10,6 +10,7 @@ import httpx
 import redteaming_ai.assessment_service as assessment_service_module
 from redteaming_ai.api import create_app
 from redteaming_ai.observability import REQUEST_ID_HEADER, get_request_id
+from redteaming_ai.storage import RunStorage
 
 
 class InlineExecutor:
@@ -127,12 +128,55 @@ def test_request_id_is_echoed_and_propagated_to_background_execution(tmp_path, c
         assert event["run_id"] == created["id"]
 
 
+def test_request_id_is_preserved_on_unhandled_500(tmp_path, caplog):
+    request_id = "req-500-123"
+
+    class BrokenRunStorage(RunStorage):
+        def create_run(self, *args, **kwargs):
+            raise RuntimeError("database unavailable")
+
+    app = create_app(
+        db_path=tmp_path / "runs.db",
+        executor=InlineExecutor(),
+        storage_cls=BrokenRunStorage,
+    )
+
+    async def scenario(client):
+        return await client.post(
+            "/assessments",
+            json={
+                "target_provider": "mock",
+                "target_model": "demo-model",
+                "target_config": {"mode": "api"},
+            },
+            headers={REQUEST_ID_HEADER: request_id},
+        )
+
+    with caplog.at_level(logging.ERROR, logger="redteaming_ai"):
+        response = asyncio.run(_run_with_client(app, scenario))
+
+    assert response.status_code == 500
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+    assert response.json() == {"detail": "Internal Server Error"}
+
+    events = _structured_events(caplog)
+    failed = next(
+        event
+        for event in events
+        if event["operation"] == "request_processing" and event["outcome"] == "failed"
+    )
+    assert failed["request_id"] == request_id
+    assert failed["method"] == "POST"
+    assert failed["path"] == "/assessments"
+    assert failed["error_type"] == "RuntimeError"
+
+
 def test_failed_assessment_logs_preserve_request_id_without_leaking_secrets(
     tmp_path, caplog
 ):
     request_id = "req-failure-123"
     observed_request_ids = []
-    secret_value = "Authorization: Bearer super-secret-token"
+    secret_value = '{"api_key": "sk-live-super-secret", "token": "runner-secret"}'
 
     def failing_runner(storage, run_id, target):
         observed_request_ids.append(get_request_id())
@@ -164,7 +208,7 @@ def test_failed_assessment_logs_preserve_request_id_without_leaking_secrets(
 
     created = response.json()
     assert created["status"] == "failed"
-    assert created["error_message"] == "Authorization: [redacted]"
+    assert created["error_message"] == '{"api_key": "[redacted]", "token": "[redacted]"}'
 
     events = _structured_events(caplog)
     failed = next(
@@ -174,13 +218,15 @@ def test_failed_assessment_logs_preserve_request_id_without_leaking_secrets(
     )
     assert failed["request_id"] == request_id
     assert failed["run_id"] == created["id"]
-    assert failed["error_message"] == "Authorization: [redacted]"
-    assert "super-secret-token" not in caplog.text
+    assert failed["error_message"] == '{"api_key": "[redacted]", "token": "[redacted]"}'
+    assert "sk-live-super-secret" not in caplog.text
+    assert "runner-secret" not in caplog.text
 
 
 def test_validation_errors_log_safe_request_context(tmp_path, caplog):
     request_id = "req-validation-123"
     leaked_text = "alice@example.com 555-111-2222 Authorization: Bearer top-secret"
+    extra_field_name = "alice@example.com"
     app = create_app(db_path=tmp_path / "runs.db", executor=InlineExecutor())
 
     async def scenario(client):
@@ -191,7 +237,7 @@ def test_validation_errors_log_safe_request_context(tmp_path, caplog):
                 "target_model": "demo-model",
                 "target_config": {"mode": "api"},
                 "attack_strategy": "invalid",
-                "unexpected": leaked_text,
+                extra_field_name: leaked_text,
             },
             headers={REQUEST_ID_HEADER: request_id},
         )
@@ -212,6 +258,7 @@ def test_validation_errors_log_safe_request_context(tmp_path, caplog):
     assert invalid["method"] == "POST"
     assert invalid["path"] == "/assessments"
     assert invalid["validation_errors"]
+    assert any("[redacted]" in error["loc"] for error in invalid["validation_errors"])
     assert "alice@example.com" not in caplog.text
     assert "555-111-2222" not in caplog.text
     assert "top-secret" not in caplog.text

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,6 @@
 import asyncio
+import json
+import logging
 import threading
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -7,6 +9,7 @@ import httpx
 
 import redteaming_ai.assessment_service as assessment_service_module
 from redteaming_ai.api import create_app
+from redteaming_ai.observability import REQUEST_ID_HEADER, get_request_id
 
 
 class InlineExecutor:
@@ -41,6 +44,177 @@ async def _create_assessment(client, payload=None):
     response = await client.post("/assessments", json=request)
     assert response.status_code == 202
     return response.json()
+
+
+def _structured_events(caplog):
+    events = []
+    for record in caplog.records:
+        if not record.name.startswith("redteaming_ai"):
+            continue
+        try:
+            events.append(json.loads(record.getMessage()))
+        except json.JSONDecodeError:
+            continue
+    return events
+
+
+def test_request_id_is_echoed_and_propagated_to_background_execution(tmp_path, caplog):
+    request_id = "req-success-123"
+    observed_request_ids = []
+
+    def scripted_runner(storage, run_id, target):
+        observed_request_ids.append(get_request_id())
+        storage.complete_run(run_id, 0.05)
+        storage.save_report(
+            run_id,
+            summary={
+                "total_attacks": 0,
+                "successful_attacks": 0,
+                "success_rate": 0.0,
+                "duration": 0.05,
+            },
+            vulnerabilities=[],
+            leaked_data_types=[],
+        )
+
+    app = create_app(
+        db_path=tmp_path / "runs.db",
+        executor=InlineExecutor(),
+        assessment_runner=scripted_runner,
+    )
+
+    async def scenario(client):
+        return await client.post(
+            "/assessments",
+            json={
+                "target_provider": "mock",
+                "target_model": "demo-model",
+                "target_config": {"mode": "api"},
+            },
+            headers={REQUEST_ID_HEADER: request_id},
+        )
+
+    with caplog.at_level(logging.INFO, logger="redteaming_ai"):
+        response = asyncio.run(_run_with_client(app, scenario))
+
+    assert response.status_code == 202
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+    assert observed_request_ids == [request_id]
+
+    created = response.json()
+    assert created["status"] == "completed"
+
+    events = _structured_events(caplog)
+    accepted = next(
+        event
+        for event in events
+        if event["operation"] == "assessment_create" and event["outcome"] == "accepted"
+    )
+    started = next(
+        event
+        for event in events
+        if event["operation"] == "assessment_execution" and event["outcome"] == "started"
+    )
+    completed = next(
+        event
+        for event in events
+        if event["operation"] == "assessment_execution"
+        and event["outcome"] == "completed"
+    )
+
+    for event in (accepted, started, completed):
+        assert event["request_id"] == request_id
+        assert event["run_id"] == created["id"]
+
+
+def test_failed_assessment_logs_preserve_request_id_without_leaking_secrets(
+    tmp_path, caplog
+):
+    request_id = "req-failure-123"
+    observed_request_ids = []
+    secret_value = "Authorization: Bearer super-secret-token"
+
+    def failing_runner(storage, run_id, target):
+        observed_request_ids.append(get_request_id())
+        raise RuntimeError(secret_value)
+
+    app = create_app(
+        db_path=tmp_path / "runs.db",
+        executor=InlineExecutor(),
+        assessment_runner=failing_runner,
+    )
+
+    async def scenario(client):
+        return await client.post(
+            "/assessments",
+            json={
+                "target_provider": "mock",
+                "target_model": "demo-model",
+                "target_config": {"mode": "api"},
+            },
+            headers={REQUEST_ID_HEADER: request_id},
+        )
+
+    with caplog.at_level(logging.INFO, logger="redteaming_ai"):
+        response = asyncio.run(_run_with_client(app, scenario))
+
+    assert response.status_code == 202
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+    assert observed_request_ids == [request_id]
+
+    created = response.json()
+    assert created["status"] == "failed"
+    assert created["error_message"] == "Authorization: [redacted]"
+
+    events = _structured_events(caplog)
+    failed = next(
+        event
+        for event in events
+        if event["operation"] == "assessment_execution" and event["outcome"] == "failed"
+    )
+    assert failed["request_id"] == request_id
+    assert failed["run_id"] == created["id"]
+    assert failed["error_message"] == "Authorization: [redacted]"
+    assert "super-secret-token" not in caplog.text
+
+
+def test_validation_errors_log_safe_request_context(tmp_path, caplog):
+    request_id = "req-validation-123"
+    leaked_text = "alice@example.com 555-111-2222 Authorization: Bearer top-secret"
+    app = create_app(db_path=tmp_path / "runs.db", executor=InlineExecutor())
+
+    async def scenario(client):
+        return await client.post(
+            "/assessments",
+            json={
+                "target_provider": "mock",
+                "target_model": "demo-model",
+                "target_config": {"mode": "api"},
+                "attack_strategy": "invalid",
+                "unexpected": leaked_text,
+            },
+            headers={REQUEST_ID_HEADER: request_id},
+        )
+
+    with caplog.at_level(logging.WARNING, logger="redteaming_ai"):
+        response = asyncio.run(_run_with_client(app, scenario))
+
+    assert response.status_code == 422
+    assert response.headers[REQUEST_ID_HEADER] == request_id
+
+    events = _structured_events(caplog)
+    invalid = next(
+        event
+        for event in events
+        if event["operation"] == "request_validation" and event["outcome"] == "invalid"
+    )
+    assert invalid["request_id"] == request_id
+    assert invalid["method"] == "POST"
+    assert invalid["path"] == "/assessments"
+    assert invalid["validation_errors"]
+    assert "alice@example.com" not in caplog.text
+    assert "555-111-2222" not in caplog.text
+    assert "top-secret" not in caplog.text
 
 
 def test_assessment_endpoints_return_report_evidence_and_export(tmp_path):


### PR DESCRIPTION
Closes #24

Summary:
- add X-Request-ID middleware to the FastAPI app
- add structured safe logging helpers and sanitize surfaced failure text
- propagate request IDs into executor-backed assessment execution
- add API tests for success, failure, and validation paths

Verification:
- uv run pytest tests/test_api.py -q
- uv run ruff check src/redteaming_ai/api.py src/redteaming_ai/assessment_service.py src/redteaming_ai/observability.py tests/test_api.py
- uv run pytest -q
- uv run ruff check